### PR TITLE
improvement: add static ip to service lb

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -134,6 +134,10 @@ resource "google_storage_hmac_key" "jgroup" {
   service_account_email = google_service_account.jgroup.email
 }
 
+resource "google_compute_global_address" "xwiki" {
+  name = "xwiki-lb-http-ip"
+}
+
 module "kubernetes_cluster" {
   depends_on = [
     module.project_services,
@@ -165,6 +169,10 @@ module "helm" {
     {
       name  = "image"
       value = var.image
+    },
+    {
+      name  = "loadbalancer_ip"
+      value = google_compute_global_address.xwiki.address
     },
     {
       name  = "config_maps.db_host"

--- a/infra/modules/helm/charts/xwiki/templates/service.yaml
+++ b/infra/modules/helm/charts/xwiki/templates/service.yaml
@@ -22,6 +22,7 @@ spec:
   selector:
     app: xwiki
   type: LoadBalancer
+  loadBalancerIP: '{{ .Values.loadbalancer_ip }}'
   sessionAffinity: ClientIP
   ports:
   - port: 80

--- a/infra/modules/helm/charts/xwiki/values.yaml
+++ b/infra/modules/helm/charts/xwiki/values.yaml
@@ -16,6 +16,7 @@ project_id: ${PROJECT_ID}
 region: ${REGION}
 
 image: ${IMAGE}
+loadbalancer_ip: ${LB_IP}
 
 config_maps:
   db_host: ${DB_HOST}

--- a/infra/output.tf
+++ b/infra/output.tf
@@ -26,3 +26,8 @@ output "jgroup_bucket_name" {
   description = "The bucket name for jgroup"
   value       = google_storage_bucket.xwiki_jgroup.name
 }
+
+output "xwiki_ip" {
+  description = "The public IP address of the XWiki application"
+  value       = google_compute_global_address.xwiki.address
+}


### PR DESCRIPTION
#### Description
- This PR adds a static Ip to the Application LB
- This way we don't have to fetch the IP once we have the cluster and the application deployed