### PR TITLE
fix: change global ip address to be regional

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -134,14 +134,20 @@ resource "google_storage_hmac_key" "jgroup" {
   service_account_email = google_service_account.jgroup.email
 }
 
-resource "google_compute_global_address" "xwiki" {
-  name = "xwiki-lb-http-ip"
+resource "google_compute_address" "xwiki" {
+  depends_on = [
+    module.project_services
+  ]
+  name          = "xwiki-lb-http-ip"
+  region = local.location["region"]
+  address_type  = "EXTERNAL"
 }
 
 module "kubernetes_cluster" {
   depends_on = [
+    module.database,
     module.project_services,
-    module.database
+    google_compute_address.xwiki
   ]
   source = "./modules/kubernetes"
 
@@ -172,7 +178,7 @@ module "helm" {
     },
     {
       name  = "loadbalancer_ip"
-      value = google_compute_global_address.xwiki.address
+      value = google_compute_address.xwiki.address
     },
     {
       name  = "config_maps.db_host"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -138,9 +138,9 @@ resource "google_compute_address" "xwiki" {
   depends_on = [
     module.project_services
   ]
-  name          = "xwiki-lb-http-ip"
-  region = local.location["region"]
-  address_type  = "EXTERNAL"
+  name         = "xwiki-lb-http-ip"
+  region       = local.location["region"]
+  address_type = "EXTERNAL"
 }
 
 module "kubernetes_cluster" {

--- a/infra/modules/helm/charts/xwiki/values.yaml
+++ b/infra/modules/helm/charts/xwiki/values.yaml
@@ -16,7 +16,7 @@ project_id: ${PROJECT_ID}
 region: ${REGION}
 
 image: ${IMAGE}
-loadbalancer_ip: ${LB_IP}
+loadbalancer_ip: ${LOADBALANCER_IP}
 
 config_maps:
   db_host: ${DB_HOST}

--- a/infra/output.tf
+++ b/infra/output.tf
@@ -29,5 +29,5 @@ output "jgroup_bucket_name" {
 
 output "xwiki_ip" {
   description = "The public IP address of the XWiki application"
-  value       = google_compute_global_address.xwiki.address
+  value       = google_compute_address.xwiki.address
 }


### PR DESCRIPTION
#### Description
- This PR is a fix for a change that went on PR #9 
- In PR #9 we added the creation of a static IP that is associated to the application's Service
- However, this would not work since the IP was a `GLOBAL` ip address
- In GKE when a Service of type `Loadbalancer` is created the load balancer that get's provisioned is a `Regional` load balancer
- Thus, the ip address allocated to it also must be a `Regional` IP address
- Thus in this PR we have changed the static ip to be a regional IP address

#### Related PRs:
- https://github.com/GoogleCloudPlatform/terraform-example-deploy-java-gke/pull/9